### PR TITLE
Added transients for video thumbnails.

### DIFF
--- a/admin/class-advanced-responsive-video-embedder-admin.php
+++ b/admin/class-advanced-responsive-video-embedder-admin.php
@@ -269,6 +269,7 @@ class Advanced_Responsive_Video_Embedder_Admin {
 
 		$output['fakethumb']      = isset( $input['fakethumb'] );
 		$output['autoplay']       = isset( $input['autoplay'] );
+		$output['use_transient']  = isset( $input['use_transient'] );
 		
 		if( (int) $input['thumb_width'] > 50 ) {
 			$output['thumb_width'] = (int) $input['thumb_width'];
@@ -283,6 +284,11 @@ class Advanced_Responsive_Video_Embedder_Admin {
 		} else {
 			$output['video_maxwidth'] = '';
 		}
+
+		if( (int) $input['transient_expire_time'] > 0 ) {
+			$output['transient_expire_time'] = (int) $input['transient_expire_time'];
+		}
+
 
 		foreach ( $input['shortcodes'] as $key => $var ) {
 		

--- a/admin/views/admin.php
+++ b/admin/views/admin.php
@@ -77,6 +77,20 @@ $options = get_option( 'arve_options', array() );
 				</td>
 			</tr>
 			<tr valign="top">
+				<th scope="row"><label for="use_transient"><?php _e('Transient thumbnails', $this->plugin_slug); ?></label></th>
+				<td>
+					<input id="arve_options[use_transient]" name="arve_options[use_transient]" type="checkbox" value="1" <?php checked( 1, $options['use_transient'] ); ?> /><br>
+					<span class='description'><?php _e('Uses Wordpress transients to cache video thumbnails that greatly speeds up page loading.', $this->plugin_slug); ?></span>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row"><label for="arve_options[transient_expire_time]"><?php _e('Transients expire time', $this->plugin_slug); ?></label></label></th>
+				<td>
+					<input id="arve_options[transient_expire_time]" name="arve_options[transient_expire_time]" type="text" value="<?php echo $options['transient_expire_time'] ?>" class="small-text">s<br>
+					<span class="description"><?php _e('The maximum of seconds to keep the thumbnail image before refreshing. For example: hour - 3600, day - 86400, week - 604800.', $this->plugin_slug); ?></span>
+				</td>
+			</tr>
+			<tr valign="top">
 				<th scope="row"><label for="autoplay"><?php _e('Autoplay all', $this->plugin_slug); ?></label></th>
 				<td>
 					<input id="arve_options[autoplay]" name="arve_options[autoplay]" type="checkbox" value="1" <?php checked( 1, $options['autoplay'] ); ?> /><br>

--- a/public/class-advanced-responsive-video-embedder.php
+++ b/public/class-advanced-responsive-video-embedder.php
@@ -346,6 +346,8 @@ class Advanced_Responsive_Video_Embedder {
 			'fakethumb'           => true,
 			'custom_thumb_image'  => '',
 			'autoplay'            => false,
+			'use_transient'       => true,
+			'transient_expire_time' => DAY_IN_SECONDS,
 			'shortcodes'          => array(
 				'archiveorg'          => 'archiveorg',
 				'blip'                => 'blip',
@@ -1066,54 +1068,63 @@ class Advanced_Responsive_Video_Embedder {
 
 		} elseif ( $mode == 'thumbnail' ) {
 
-			switch ($provider) {
-				case 'youtube':
+                        $transient_name = $provider . '_' . $id;
+                        if($options['use_transient'] && get_transient($transient_name)) {
+                                $thumbnail = get_transient($transient_name);
+                        }
+                        else {
+                                switch ($provider) {
+                                        case 'youtube':
 
-					$thumbnail = 'http://img.youtube.com/vi/' . $id . '/0.jpg';
-					break;
+                                                $thumbnail = 'http://img.youtube.com/vi/' . $id . '/0.jpg';
+                                                break;
 
-				case 'vimeo':
+                                        case 'vimeo':
+                                                if ( $vimeo_hash = unserialize(file_get_contents('http://vimeo.com/api/v2/video/' . $id . '.php')) ) {
+                                                        $thumbnail = (string) $vimeo_hash[0]['thumbnail_large'];
+                                                } else {
+                                                        return "<p><strong>ARVE Error:</strong> could not get Vimeo thumbnail";
+                                                }
+                                                
+                                                break;
+                
+                                        case 'blip':
+                                        case 'bliptv':
 
-					if ( $vimeo_hash = unserialize(file_get_contents('http://vimeo.com/api/v2/video/' . $id . '.php')) ) {
-						$thumbnail = (string) $vimeo_hash[0]['thumbnail_large'];
-					} else {
-						return "<p><strong>ARVE Error:</strong> could not get Vimeo thumbnail";
-					}
-					break;
-	
-				case 'blip':
-				case 'bliptv':
+                                                if ( $blip_xml = simplexml_load_file( "http://blip.tv/players/episode/$id?skin=rss" ) ) {
+                                                        $blip_result = $blip_xml->xpath( "/rss/channel/item/media:thumbnail/@url" );
+                                                        $thumbnail = (string) $blip_result[0]['url'];
+                                                } else {
+                                                        return '<p><strong>ARVE Error:</strong> could not get Blip.tv thumbnail</p>';
+                                                }
+                                                break;
 
-					if ( $blip_xml = simplexml_load_file( "http://blip.tv/players/episode/$id?skin=rss" ) ) {
-						$blip_result = $blip_xml->xpath( "/rss/channel/item/media:thumbnail/@url" );
-						$thumbnail = (string) $blip_result[0]['url'];
-					} else {
-						return '<p><strong>ARVE Error:</strong> could not get Blip.tv thumbnail</p>';
-					}
-					break;
+                                        case 'dailymotion':
 
-				case 'dailymotion':
+                                                $thumbnail = 'http://www.dailymotion.com/thumbnail/video/' . $id;
+                                                break;
 
-					$thumbnail = 'http://www.dailymotion.com/thumbnail/video/' . $id;
-					break;
+                                        case 'dailymotionlist':
 
-				case 'dailymotionlist':
+                                                $dayli_api = file_get_contents( 'https://api.dailymotion.com/playlist/' . $id . '?fields=thumbnail_large_url' );
+                                                $dayli_api = json_decode( $dayli_api, true );
 
-					$dayli_api = file_get_contents( 'https://api.dailymotion.com/playlist/' . $id . '?fields=thumbnail_large_url' );
-					$dayli_api = json_decode( $dayli_api, true );
+                                                $thumbnail = (string) $dayli_api['thumbnail_large_url'];
 
-					$thumbnail = (string) $dayli_api['thumbnail_large_url'];
+                                                if ( empty( $thumbnail ) ) {
+                                                        return "<p><strong>ARVE Error:</strong> could not get Thumbnail for this dailymotion playlist";
+                                                }
 
-					if ( empty( $thumbnail ) ) {
-						return "<p><strong>ARVE Error:</strong> could not get Thumbnail for this dailymotion playlist";
-					}
-
-					break;
-			}
+                                                break;
+                                }
+                        }
 			
 			$thumb_bg = '';
 
 			if ( $thumbnail ) {
+                                if ($options['use_transient']) {
+                                        set_transient($transient_name, $thumbnail, $options['transient_expire_time']);
+                                }
 				$thumb_bg = sprintf( ' style="background-image: url(%s);"', esc_url( $thumbnail ) );
 			}
 			elseif ( ! empty( $options['custom_thumb_image'] ) ) {


### PR DESCRIPTION
Hello!
I indeed liked your WP plugin, but there was an issue with thumbnails - page with 10+ videos (in fake thumbnail mode) take 10 seconds to load. So I used WP transients to cache them and got 10x speedup.
Though, tested it only with vimeo.
