### PR TITLE
Fixed pathing of TinyMCE icon through addition of "wp_localize_script" c...

### DIFF
--- a/admin/assets/js/mce-plugin.js
+++ b/admin/assets/js/mce-plugin.js
@@ -10,7 +10,7 @@
 				// creates the button
 				var button = controlManager.createButton('arve_button', {
 					title : 'Embed Videos', // title of the button
-					image : '../wp-content/plugins/advanced-responsive-video-embedder/admin/assets/img/tinymce-icon.png',  // path to the button's image
+					image : arve_mce_icon,  // path to the button's image
 					onclick : function() {
 						// triggers the thickbox
 						var width = jQuery(window).width(),

--- a/admin/class-advanced-responsive-video-embedder-admin.php
+++ b/admin/class-advanced-responsive-video-embedder-admin.php
@@ -164,7 +164,7 @@ class Advanced_Responsive_Video_Embedder_Admin {
         }
 
 		wp_localize_script( 'jquery', 'arve_regex_list', $regex_list );
-
+		wp_localize_script( 'jquery', 'arve_mce_icon', plugins_url( 'assets/img/tinymce-icon.png', __FILE__ ) );
 	}
 
 	/**


### PR DESCRIPTION
Hey there!

I use a custom location for my WordPress plugins (both not wp-content and within mu-plugins). This was causing the custom TinyMCE icon to break for the video embeds through your application (doh!). I added a quick localization fix to your base administrative class (admin/class-advanced-responsive-video-embedder-admin.php) and updated your TinyMCE plugin (admin/assets/js/mce-plugin.js) to match.

Tested things and it looks to be AOK - let me know if you would like any more details!

Thanks for such a great piece of code =)

Cheers,
- folkhack
