### PR TITLE
Update Support for youtu.be short links

### DIFF
--- a/includes/class-advanced-responsive-video-embedder-shared.php
+++ b/includes/class-advanced-responsive-video-embedder-shared.php
@@ -195,7 +195,7 @@ class Advanced_Responsive_Video_Embedder_Shared {
 			'xtube'               => $hw . 'xtube\.com/watch\.php\?v=([a-z0-9_\-]+)',
 			'youtube'             => $hw . 'youtube\.com/watch\?v=([a-z0-9_\-]{11}(&list=[a-z0-9_\-]+)?)',
 			//* Shorteners
-			'youtu_be'            => 'http://youtu\.be/([a-z0-9_-]{11})',
+			'youtu_be'            => $hw . 'youtu\.be/([a-z0-9_-]{11})',
 			'dai_ly'              => 'http://dai\.ly/([^_]+)',
 		);
 	}


### PR DESCRIPTION
By Default YouTube is using https for their short links and this fixes the problem.

Also I know nothing about regex but should the code be `([A-z0-9_-]{11})` with a capital A?