### PR TITLE
Dailymotion problem with https websites

### DIFF
--- a/public/class-advanced-responsive-video-embedder-public.php
+++ b/public/class-advanced-responsive-video-embedder-public.php
@@ -474,7 +474,7 @@ class Advanced_Responsive_Video_Embedder_Public {
 				$urlcode = 'http://break.com/embed/' . $id;
 				break;
 			case 'dailymotion':
-				$urlcode = 'http://www.dailymotion.com/embed/video/' . $id;
+				$urlcode = '//www.dailymotion.com/embed/video/' . $id;
 				break;
 			case 'dailymotionlist':
 				$urlcode = 'http://www.dailymotion.com/widget/jukebox?list[]=%2Fplaylist%2F' . $id . '%2F1';


### PR DESCRIPTION
Hello there,

The current plugin always creates a http:// adress for dailymotion. This can bring cross-domain problems in https websites, and should be fixed since dailymotion can provide its videos through https.

I'm a novice with PHP, so I only made what seemed the most obvious and quick-to-do change. I guess there are other changes that should be made in other parts, but I didn't check.